### PR TITLE
refactor(nix): update flake-parts modules

### DIFF
--- a/crates/cli/src/commands/dev.rs
+++ b/crates/cli/src/commands/dev.rs
@@ -81,7 +81,7 @@ pub async fn async_debounce_watch<P: AsRef<Path>>(
             }
             Err(errors) => {
                 for error in errors {
-                    println!("error: {:?}", error);
+                    println!("error: {error:?}");
                 }
             }
         }

--- a/crates/http/src/serve.rs
+++ b/crates/http/src/serve.rs
@@ -49,7 +49,7 @@ pub(crate) async fn inject_variables_into_html(
             let values = state
                 .variables
                 .iter()
-                .map(|(key, value)| (format!("data-{}", key), value))
+                .map(|(key, value)| (format!("data-{key}"), value))
                 .collect::<Vec<_>>();
             // Get the values as references
             let mut values = values

--- a/crates/watcher/src/lib.rs
+++ b/crates/watcher/src/lib.rs
@@ -185,16 +185,14 @@ pub async fn new_async_debouncer_opt<F: AsyncDebounceEventHandler + Send + 'stat
         Some(v) => {
             if v > timeout {
                 return Err(Error::new(ErrorKind::Generic(format!(
-                    "Invalid tick_rate, tick rate {:?} > {:?} timeout!",
-                    v, timeout
+                    "Invalid tick_rate, tick rate {v:?} > {timeout:?} timeout!"
                 ))));
             }
             v
         }
         None => timeout.checked_div(tick_div).ok_or_else(|| {
             Error::new(ErrorKind::Generic(format!(
-                "Failed to calculate tick as {:?}/{}!",
-                timeout, tick_div
+                "Failed to calculate tick as {timeout:?}/{tick_div}!"
             )))
         })?,
     };

--- a/flake-parts/cargo.nix
+++ b/flake-parts/cargo.nix
@@ -14,21 +14,6 @@
     self',
     ...
   }: let
-    devTools = [
-      # rust tooling
-      self'.packages.rust-toolchain
-      pkgs.cargo-audit
-      pkgs.cargo-udeps
-      pkgs.bacon
-      # version control
-      pkgs.cocogitto
-      inputs'.bomper.packages.cli
-      # nodejs
-      self'.packages.nodejs
-      self'.packages.yarn
-      # misc
-    ];
-
     # packages required for building the rust packages
     extraPackages = [
       pkgs.pkg-config
@@ -56,7 +41,39 @@
 
     deps-only = craneLib.buildDepsOnly ({} // common-build-args);
 
-    packages = {
+    packages = let
+      buildWasmPackage = {
+        name,
+        wasm-bindgen-target ? "web",
+      }:
+        craneLib.mkCargoDerivation (let
+          # convert the name to underscored
+          underscore_name = pkgs.lib.strings.replaceStrings ["-"] ["_"] name;
+        in
+          {
+            pname = name;
+            cargoArtifacts = deps-only;
+            cargoExtraArgs = "-p ${name} --target wasm32-unknown-unknown";
+            doCheck = false;
+            doInstallCargoArtifacts = false;
+
+            buildPhaseCargoCommand = ''
+              cargoBuildLog=$(mktemp cargoBuildLogXXXX.json)
+              cargoWithProfile build -p ${name} --target wasm32-unknown-unknown --message-format json-render-diagnostics > $cargoBuildLog
+
+              ${pkgs.wasm-bindgen-cli}/bin/wasm-bindgen \
+                target/wasm32-unknown-unknown/release/${underscore_name}.wasm \
+                --out-dir $out \
+                --target ${wasm-bindgen-target} \
+
+              ${pkgs.binaryen}/bin/wasm-opt \
+                -Oz \
+                --output $out/${underscore_name}_bg.wasm \
+                $out/${underscore_name}_bg.wasm
+            '';
+          }
+          // common-build-args);
+    in {
       default = packages.cli;
       cli = craneLib.buildPackage ({
           pname = "annapurna-cli";
@@ -93,21 +110,16 @@
   in rec {
     inherit packages checks;
 
-    devShells.default = pkgs.mkShell rec {
-      packages = withExtraPackages devTools;
-      LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath packages;
-
-      shellHook = ''
-        ${config.pre-commit.installationScript}
-      '';
-    };
-
     apps = {
       cli = {
         type = "app";
         program = pkgs.lib.getBin self'.packages.cli;
       };
       default = apps.cli;
+    };
+
+    legacyPackages = {
+      cargoExtraPackages = extraPackages;
     };
   };
 }

--- a/flake-parts/ci.nix
+++ b/flake-parts/ci.nix
@@ -1,0 +1,30 @@
+{inputs, ...}: {
+  perSystem = {
+    config,
+    pkgs,
+    system,
+    inputs',
+    self',
+    ...
+  }: let
+    ciPackages = [
+    ];
+
+    packages = {
+    };
+
+    devShells = {
+      ci = pkgs.mkShell rec {
+        packages = ciPackages;
+
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath packages;
+      };
+    };
+  in rec {
+    inherit devShells packages;
+
+    legacyPackages = {
+      inherit ciPackages;
+    };
+  };
+}

--- a/flake-parts/formatting.nix
+++ b/flake-parts/formatting.nix
@@ -1,0 +1,32 @@
+{
+  inputs,
+  self,
+  ...
+}: {
+  perSystem = {
+    pkgs,
+    lib,
+    ...
+  }: let
+    formatters = [
+      pkgs.alejandra
+      pkgs.rustfmt
+    ];
+
+    treefmt = pkgs.writeShellApplication {
+      name = "treefmt";
+      runtimeInputs = [pkgs.treefmt] ++ formatters;
+      text = ''
+        exec treefmt "$@"
+      '';
+    };
+  in {
+    packages = {
+      inherit treefmt;
+    };
+
+    legacyPackages = {
+      inherit formatters;
+    };
+  };
+}

--- a/flake-parts/pre-commit.nix
+++ b/flake-parts/pre-commit.nix
@@ -3,20 +3,18 @@
   self,
   ...
 }: {
-  perSystem = {
-    pkgs,
-    self',
-    ...
-  }: {
+  perSystem = {self', ...}: let
+  in {
     pre-commit = {
-      check.enable = false;
+      check.enable = true;
 
       settings = {
         src = ../.;
         hooks = {
-          alejandra.enable = true;
-          rustfmt.enable = true;
+          treefmt.enable = true;
         };
+
+        settings.treefmt.package = self'.packages.treefmt;
       };
     };
   };

--- a/flake-parts/rust-toolchain.nix
+++ b/flake-parts/rust-toolchain.nix
@@ -1,28 +1,25 @@
-{
-  inputs,
-  self,
-  ...
-} @ part-inputs: {
-  imports = [];
+{...}: {
+  perSystem = {inputs', ...}: let
+    # "stable", "latest", "minimal", "complete"
+    channel = "latest";
+    fenix-channel = inputs'.fenix.packages.${channel};
 
-  perSystem = {
-    pkgs,
-    lib,
-    system,
-    inputs',
-    ...
-  }: let
-    fenix-channel = inputs'.fenix.packages.stable;
-    # fenix-channel = inputs'.fenix.packages.latest;
-    fenix-toolchain = fenix-channel.withComponents [
-      "rustc"
-      "cargo"
-      "clippy"
-      "rust-analysis"
-      "rust-src"
-      "rustfmt"
-      "llvm-tools-preview"
+    # rust targets
+    fenix-targets = with inputs'.fenix.packages.targets; [
+      x86_64-unknown-linux-gnu.${channel}.rust-std
+      # wasm32-unknown-unknown.${channel}.rust-std
     ];
+
+    fenix-toolchain = inputs'.fenix.packages.combine ([
+        fenix-channel.rustc
+        fenix-channel.cargo
+        fenix-channel.clippy
+        fenix-channel.rust-analysis
+        fenix-channel.rust-src
+        fenix-channel.rustfmt
+        fenix-channel.llvm-tools-preview
+      ]
+      ++ fenix-targets);
   in rec {
     packages = {
       rust-toolchain = fenix-toolchain;

--- a/flake-parts/shells.nix
+++ b/flake-parts/shells.nix
@@ -1,0 +1,44 @@
+{inputs, ...}: {
+  perSystem = {
+    config,
+    pkgs,
+    system,
+    inputs',
+    self',
+    lib,
+    ...
+  }: let
+    inherit (self'.packages) rust-toolchain;
+    inherit (self'.legacyPackages) cargoExtraPackages ciPackages;
+
+    devTools = [
+      # rust tooling
+      rust-toolchain
+      pkgs.cargo-audit
+      pkgs.cargo-udeps
+      pkgs.bacon
+      pkgs.wasm-bindgen-cli
+      # version control
+      pkgs.cocogitto
+      inputs'.bomper.packages.cli
+      # nodejs
+      self'.packages.nodejs
+      self'.packages.yarn
+      # formatting
+      self'.packages.treefmt
+    ];
+  in {
+    devShells = {
+      default = pkgs.mkShell rec {
+        packages = devTools ++ cargoExtraPackages ++ ciPackages;
+
+        LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath packages;
+        RUST_SRC_PATH = "${self'.packages.rust-toolchain}/lib/rustlib/src/rust/src";
+
+        shellHook = ''
+          ${config.pre-commit.installationScript}
+        '';
+      };
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -468,12 +468,15 @@
       }
     },
     "flake-utils_12": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -780,16 +783,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1671271954,
-        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -962,11 +965,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1673627351,
-        "narHash": "sha256-oppRxEg/7ICcG67ErBvu1UlXt3su6zMcNoQmKaHPs5I=",
+        "lastModified": 1686668298,
+        "narHash": "sha256-AADh9NqHh6X2LOem4BvI7oCkMm+JPCSCE7iIw5nn0VA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "496e4505c2ddf5f205242eae8064d7d89cd976c0",
+        "rev": "5b6b54d3f722aa95cbf4ddbe35390a0af8c0015a",
         "type": "github"
       },
       "original": {
@@ -1108,6 +1111,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -37,13 +37,18 @@
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux"];
       imports = [
-        inputs.dream2nix.flakeModuleBeta
-        inputs.pre-commit-hooks.flakeModule
-
         ./flake-parts/astro.nix
-        ./flake-parts/cargo.nix
-        ./flake-parts/pre-commit.nix
+        inputs.dream2nix.flakeModuleBeta
+
         ./flake-parts/rust-toolchain.nix
+        ./flake-parts/cargo.nix
+
+        ./flake-parts/ci.nix
+        ./flake-parts/shells.nix
+
+        ./flake-parts/formatting.nix
+        ./flake-parts/pre-commit.nix
+        inputs.pre-commit-hooks.flakeModule
       ];
     };
 }

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,8 @@
+[formatter.rust]
+command = "rustfmt"
+options = ["--edition", "2021"]
+includes = ["*.rs"]
+
+[formatter.nix]
+command = "alejandra"
+includes = ["*.nix"]


### PR DESCRIPTION
This separates concerns from some files. Previously `cargo.nix` was responsible for the default devShell, but this is no longer the case. There is now a separate CI devShell. The rust tooling has been modified in preparation of compiling to WASM. The pre-commit-hooks have been changed to use treefmt.