### PR TITLE
chore: update async-watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "async-watcher"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f592305b7e0a9375714169a15870cd1c75763ca58a40e3d9a9d55d7d969f128"
+checksum = "bacb0b348a5dc507de0234ae0627d09c6f5ca6d257a084872f01a294616b9517"
 dependencies = [
  "async-trait",
  "notify",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 annapurna-data = { path = "../data" }
 annapurna-logic = { path = "../logic" }
 annapurna-http = { path = "../http" }
-async-watcher = "0.1.1"
+async-watcher = "0.2.0"
 clap = { version = "4.1.13", features = ["derive"] }
 config = "0.13.3"
 gix-discover = "0.16.1"


### PR DESCRIPTION
Updating to 0.2.0 allows us to remove the `async_debounce_watch` function and instead use a channel created by the library. This simplifies the server dev command.