### PR TITLE
feat(services): added postgres service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ result*
 target
 
 .static
+.data

--- a/flake-parts/postgres.nix
+++ b/flake-parts/postgres.nix
@@ -1,0 +1,14 @@
+{...} @ part-inputs: {
+  imports = [];
+
+  perSystem = {
+    pkgs,
+    inputs',
+    self',
+    ...
+  }: {
+    packages = {
+      postgresql = inputs'.nix-postgres.packages."psql_15/bin";
+    };
+  };
+}

--- a/flake-parts/services.nix
+++ b/flake-parts/services.nix
@@ -1,0 +1,45 @@
+{inputs, ...} @ part-inputs: {
+  imports = [];
+
+  perSystem = {
+    pkgs,
+    inputs',
+    self',
+    ...
+  }: let
+    ports = {
+      annapurna-postgres = "\${ANNAPURNA_POSTGRES_PORT}";
+    };
+
+    global-imports = [
+      ({name, ...}: {
+        dataDirEnv = "\${PRJ_DATA_HOME}/${name}";
+        socketDirEnv = "\${PRJ_DATA_HOME}/${name}/sockets";
+      })
+    ];
+  in rec {
+    process-compose = {
+      services = {
+        imports = [
+          inputs.services-flake.processComposeModules.default
+        ];
+
+        services.postgres."annapurna-postgres" = {
+          imports = global-imports;
+
+          enable = true;
+          package = self'.packages.postgresql;
+
+          # by not including a listen address, we only listen on the unix socket
+          # listen_addresses = "127.0.0.1";
+          port = ports.annapurna-postgres;
+          initialDatabases = [
+            {
+              name = "annapurna-local";
+            }
+          ];
+        };
+      };
+    };
+  };
+}

--- a/flake-parts/shells.nix
+++ b/flake-parts/shells.nix
@@ -8,7 +8,7 @@
     lib,
     ...
   }: let
-    inherit (self'.packages) rust-toolchain;
+    inherit (self'.packages) rust-toolchain postgresql;
     inherit (self'.legacyPackages) cargoExtraPackages ciPackages;
 
     devTools = [
@@ -21,6 +21,8 @@
       pkgs.wasm-bindgen-cli
       # formatting
       self'.packages.treefmt
+
+      postgresql
     ];
   in {
     devShells = {

--- a/flake.lock
+++ b/flake.lock
@@ -56,10 +56,10 @@
     "bomper_3": {
       "inputs": {
         "bomper": "bomper_4",
-        "crane": "crane_5",
-        "fenix": "fenix_5",
-        "flake-parts": "flake-parts_5",
-        "nix-filter": "nix-filter_5",
+        "crane": "crane_6",
+        "fenix": "fenix_6",
+        "flake-parts": "flake-parts_6",
+        "nix-filter": "nix-filter_6",
         "nixpkgs": [
           "wasm-bindgen-service-worker",
           "nixpkgs"
@@ -82,11 +82,11 @@
     },
     "bomper_4": {
       "inputs": {
-        "crane": "crane_4",
-        "fenix": "fenix_4",
-        "flake-parts": "flake-parts_4",
-        "flake-utils": "flake-utils_11",
-        "nix-filter": "nix-filter_4",
+        "crane": "crane_5",
+        "fenix": "fenix_5",
+        "flake-parts": "flake-parts_5",
+        "flake-utils": "flake-utils_15",
+        "nix-filter": "nix-filter_5",
         "nixpkgs": [
           "wasm-bindgen-service-worker",
           "bomper",
@@ -182,22 +182,21 @@
     },
     "crane_4": {
       "inputs": {
-        "flake-compat": "flake-compat_7",
+        "flake-compat": "flake-compat_6",
         "flake-utils": "flake-utils_10",
         "nixpkgs": [
-          "wasm-bindgen-service-worker",
-          "bomper",
-          "bomper",
+          "nix-postgres",
+          "pgx-ulid",
           "nixpkgs"
         ],
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1684468982,
-        "narHash": "sha256-EoC1N5sFdmjuAP3UOkyQujSOT6EdcXTnRw8hPjJkEgc=",
+        "lastModified": 1679285709,
+        "narHash": "sha256-oERwmwZPZ5BOqSv6cmcXfjIBPrFR6dp02oGE8mA+1n4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "99de890b6ef4b4aab031582125b6056b792a4a30",
+        "rev": "2552a2d1ccf33d43259a9e00f93dbacb9e6d6bed",
         "type": "github"
       },
       "original": {
@@ -208,14 +207,15 @@
     },
     "crane_5": {
       "inputs": {
-        "flake-compat": "flake-compat_9",
-        "flake-utils": "flake-utils_13",
+        "flake-compat": "flake-compat_8",
+        "flake-utils": "flake-utils_14",
         "nixpkgs": [
           "wasm-bindgen-service-worker",
           "bomper",
+          "bomper",
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_5"
+        "rust-overlay": "rust-overlay_6"
       },
       "locked": {
         "lastModified": 1684468982,
@@ -233,13 +233,38 @@
     },
     "crane_6": {
       "inputs": {
-        "flake-compat": "flake-compat_11",
-        "flake-utils": "flake-utils_15",
+        "flake-compat": "flake-compat_10",
+        "flake-utils": "flake-utils_17",
+        "nixpkgs": [
+          "wasm-bindgen-service-worker",
+          "bomper",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_7"
+      },
+      "locked": {
+        "lastModified": 1684468982,
+        "narHash": "sha256-EoC1N5sFdmjuAP3UOkyQujSOT6EdcXTnRw8hPjJkEgc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "99de890b6ef4b4aab031582125b6056b792a4a30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_7": {
+      "inputs": {
+        "flake-compat": "flake-compat_12",
+        "flake-utils": "flake-utils_19",
         "nixpkgs": [
           "wasm-bindgen-service-worker",
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_6"
+        "rust-overlay": "rust-overlay_8"
       },
       "locked": {
         "lastModified": 1680584903,
@@ -324,19 +349,18 @@
     "fenix_4": {
       "inputs": {
         "nixpkgs": [
-          "wasm-bindgen-service-worker",
-          "bomper",
-          "bomper",
+          "nix-postgres",
+          "pgx-ulid",
           "nixpkgs"
         ],
         "rust-analyzer-src": "rust-analyzer-src_4"
       },
       "locked": {
-        "lastModified": 1684909271,
-        "narHash": "sha256-jaBSRiB/6bQocsdAd+LGNJydB1B9BuKKn8V6spi0Nxg=",
+        "lastModified": 1709101340,
+        "narHash": "sha256-C5DqUNDlcI6t11w14MMIt0ojLOD05m35ea9DQ7gIQpY=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8f2abd362e6a93c0e0ddc3c8dc7734a6a1c9f894",
+        "rev": "daa2bef600e492c137c34d01792e10067589c31d",
         "type": "github"
       },
       "original": {
@@ -349,6 +373,7 @@
       "inputs": {
         "nixpkgs": [
           "wasm-bindgen-service-worker",
+          "bomper",
           "bomper",
           "nixpkgs"
         ],
@@ -372,9 +397,32 @@
       "inputs": {
         "nixpkgs": [
           "wasm-bindgen-service-worker",
+          "bomper",
           "nixpkgs"
         ],
         "rust-analyzer-src": "rust-analyzer-src_6"
+      },
+      "locked": {
+        "lastModified": 1684909271,
+        "narHash": "sha256-jaBSRiB/6bQocsdAd+LGNJydB1B9BuKKn8V6spi0Nxg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "8f2abd362e6a93c0e0ddc3c8dc7734a6a1c9f894",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix_7": {
+      "inputs": {
+        "nixpkgs": [
+          "wasm-bindgen-service-worker",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_7"
       },
       "locked": {
         "lastModified": 1695536378,
@@ -439,6 +487,22 @@
       }
     },
     "flake-compat_12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_13": {
       "flake": false,
       "locked": {
         "lastModified": 1673956053,
@@ -677,6 +741,24 @@
         "nixpkgs-lib": "nixpkgs-lib_6"
       },
       "locked": {
+        "lastModified": 1678379998,
+        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_7": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_7"
+      },
+      "locked": {
         "lastModified": 1680392223,
         "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
         "owner": "hercules-ci",
@@ -709,15 +791,12 @@
       }
     },
     "flake-utils_10": {
-      "inputs": {
-        "systems": "systems_7"
-      },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -728,11 +807,11 @@
     },
     "flake-utils_11": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -742,12 +821,15 @@
       }
     },
     "flake-utils_12": {
+      "inputs": {
+        "systems": "systems_7"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -761,6 +843,24 @@
         "systems": "systems_8"
       },
       "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_14": {
+      "inputs": {
+        "systems": "systems_9"
+      },
+      "locked": {
         "lastModified": 1681202837,
         "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
@@ -774,28 +874,13 @@
         "type": "github"
       }
     },
-    "flake-utils_14": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_15": {
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -819,6 +904,54 @@
         "type": "github"
       }
     },
+    "flake-utils_17": {
+      "inputs": {
+        "systems": "systems_10"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_18": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_19": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_2": {
       "locked": {
         "lastModified": 1656928814,
@@ -826,6 +959,21 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_20": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -922,11 +1070,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -940,11 +1088,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -1001,16 +1149,18 @@
     "gitignore_3": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "nix-postgres",
+          "pgx-ulid",
+          "pgx",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1694102001,
+        "narHash": "sha256-vky6VPK1n1od6vXbqzOXnekrQpTL4hbPAwUhT5J9c9E=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "9e21c80adf67ebcb077d75bd5e7d724d21eeafd6",
         "type": "github"
       },
       "original": {
@@ -1022,9 +1172,6 @@
     "gitignore_4": {
       "inputs": {
         "nixpkgs": [
-          "wasm-bindgen-service-worker",
-          "bomper",
-          "bomper",
           "pre-commit-hooks",
           "nixpkgs"
         ]
@@ -1048,6 +1195,7 @@
         "nixpkgs": [
           "wasm-bindgen-service-worker",
           "bomper",
+          "bomper",
           "pre-commit-hooks",
           "nixpkgs"
         ]
@@ -1070,6 +1218,7 @@
       "inputs": {
         "nixpkgs": [
           "wasm-bindgen-service-worker",
+          "bomper",
           "pre-commit-hooks",
           "nixpkgs"
         ]
@@ -1085,6 +1234,73 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_7": {
+      "inputs": {
+        "nixpkgs": [
+          "wasm-bindgen-service-worker",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-postgres",
+          "pgx-ulid",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679381791,
+        "narHash": "sha256-VOhLgeFKyovk93wPGaYM+isCA053EHHPpzeR7fvonyU=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "5c8dbab3d9fe3b3e5796f505bda2af9414bf1ddd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "naersk_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-postgres",
+          "pgx-ulid",
+          "pgx",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1694081375,
+        "narHash": "sha256-vzJXOUnmkMCm3xw8yfPP5m8kypQ3BhAIRe4RRCWpzy8=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "3f976d822b7b37fc6fb8e6f157c2dd05e7e94e89",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
         "type": "github"
       }
     },
@@ -1178,9 +1394,64 @@
         "type": "github"
       }
     },
-    "nix2container": {
+    "nix-filter_7": {
+      "locked": {
+        "lastModified": 1678109515,
+        "narHash": "sha256-C2X+qC80K2C1TOYZT8nabgo05Dw2HST/pSn6s+n6BO8=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "aa9ff6ce4a7f19af6415fb3721eaa513ea6c763c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-postgres": {
       "inputs": {
         "flake-utils": "flake-utils_8",
+        "nix2container": "nix2container",
+        "nixpkgs": "nixpkgs_4",
+        "pgx-ulid": "pgx-ulid"
+      },
+      "locked": {
+        "lastModified": 1709503648,
+        "narHash": "sha256-hoxcIerVhPqMUOrnyhH1FDGaCz2sKFsZ5KYUejXD5sY=",
+        "owner": "justinrubek",
+        "repo": "nix-postgres",
+        "rev": "51628dc4350a56d6427ca9d86187eabb59671e33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinrubek",
+        "repo": "nix-postgres",
+        "type": "github"
+      }
+    },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": "flake-utils_9",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1708764364,
+        "narHash": "sha256-+pOtDvmuVTg0Gi58hKDUyrNla5NbyUvt3Xs3gLR0Fws=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "c891f90d2e3c48a6b33466c96e4851e0fc0cf455",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
+    "nix2container_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_12",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1306,6 +1577,24 @@
       }
     },
     "nixpkgs-lib_6": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1678375444,
+        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_7": {
       "locked": {
         "dir": "lib",
         "lastModified": 1680213900,
@@ -1437,6 +1726,52 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1697269602,
+        "narHash": "sha256-dSzV7Ud+JH4DPVD9od53EgDrxUVQOcSj4KGjggCDVJI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9cb540e9c1910d74a7e10736277f6eb9dff51c81",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1708847675,
+        "narHash": "sha256-RUZ7KEs/a4EzRELYDGnRB6i7M1Izii3JD/LyzH0c6Tg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2a34566b67bef34c551f204063faeecc444ae9da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1708984720,
+        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1709237383,
         "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
@@ -1450,7 +1785,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1681303793,
         "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
@@ -1466,7 +1801,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1681303793,
         "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
@@ -1482,7 +1817,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1695360818,
         "narHash": "sha256-JlkN3R/SSoMTa+CasbxS1gq+GpGxXQlNZRUh9+LIy/0=",
@@ -1495,6 +1830,61 @@
         "id": "nixpkgs",
         "ref": "nixos-unstable",
         "type": "indirect"
+      }
+    },
+    "pgx": {
+      "inputs": {
+        "fenix": [
+          "nix-postgres",
+          "pgx-ulid",
+          "fenix"
+        ],
+        "gitignore": "gitignore_3",
+        "naersk": "naersk_2",
+        "nixpkgs": [
+          "nix-postgres",
+          "pgx-ulid",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698779972,
+        "narHash": "sha256-BB9ftsLYwc4sd6c7JI8gyG9brL+PXq6Ep82fXiN3sDQ=",
+        "owner": "pgcentralfoundation",
+        "repo": "pgrx",
+        "rev": "16364772b42e66315c152743c0fd06c09ef6345b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pgcentralfoundation",
+        "repo": "pgrx",
+        "rev": "16364772b42e66315c152743c0fd06c09ef6345b",
+        "type": "github"
+      }
+    },
+    "pgx-ulid": {
+      "inputs": {
+        "crane": "crane_4",
+        "fenix": "fenix_4",
+        "flake-parts": "flake-parts_4",
+        "naersk": "naersk",
+        "nix-filter": "nix-filter_4",
+        "nixpkgs": "nixpkgs_5",
+        "pgx": "pgx",
+        "rust-overlay": "rust-overlay_5"
+      },
+      "locked": {
+        "lastModified": 1709214141,
+        "narHash": "sha256-6/A9TMnKCIXFLBWAVc8m9g8oKIrV76OBFCUgsWH4F0o=",
+        "owner": "justinrubek",
+        "repo": "pgx_ulid",
+        "rev": "1562908b55170ff9602e18df4c212a934140ce16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinrubek",
+        "repo": "pgx_ulid",
+        "type": "github"
       }
     },
     "pre-commit-hooks": {
@@ -1543,9 +1933,9 @@
     },
     "pre-commit-hooks_3": {
       "inputs": {
-        "flake-compat": "flake-compat_6",
-        "flake-utils": "flake-utils_9",
-        "gitignore": "gitignore_3",
+        "flake-compat": "flake-compat_7",
+        "flake-utils": "flake-utils_13",
+        "gitignore": "gitignore_4",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1567,10 +1957,10 @@
     },
     "pre-commit-hooks_4": {
       "inputs": {
-        "flake-compat": "flake-compat_8",
-        "flake-utils": "flake-utils_12",
-        "gitignore": "gitignore_4",
-        "nixpkgs": "nixpkgs_4",
+        "flake-compat": "flake-compat_9",
+        "flake-utils": "flake-utils_16",
+        "gitignore": "gitignore_5",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-stable": "nixpkgs-stable_4"
       },
       "locked": {
@@ -1589,10 +1979,10 @@
     },
     "pre-commit-hooks_5": {
       "inputs": {
-        "flake-compat": "flake-compat_10",
-        "flake-utils": "flake-utils_14",
-        "gitignore": "gitignore_5",
-        "nixpkgs": "nixpkgs_5",
+        "flake-compat": "flake-compat_11",
+        "flake-utils": "flake-utils_18",
+        "gitignore": "gitignore_6",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-stable": "nixpkgs-stable_5"
       },
       "locked": {
@@ -1611,9 +2001,9 @@
     },
     "pre-commit-hooks_6": {
       "inputs": {
-        "flake-compat": "flake-compat_12",
-        "flake-utils": "flake-utils_16",
-        "gitignore": "gitignore_6",
+        "flake-compat": "flake-compat_13",
+        "flake-utils": "flake-utils_20",
+        "gitignore": "gitignore_7",
         "nixpkgs": [
           "wasm-bindgen-service-worker",
           "nixpkgs"
@@ -1634,6 +2024,21 @@
         "type": "github"
       }
     },
+    "process-compose": {
+      "locked": {
+        "lastModified": 1708624100,
+        "narHash": "sha256-zZPheCD9JGg2EtK4A9BsIdyl8447egOow4fjIfHFHRg=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "44d260ddba5a51570dee54d5cd4d8984edaf98c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "bomper": "bomper",
@@ -1642,9 +2047,12 @@
         "flake-parts": "flake-parts_3",
         "flake-utils": "flake-utils_7",
         "nix-filter": "nix-filter_3",
-        "nix2container": "nix2container",
-        "nixpkgs": "nixpkgs_3",
+        "nix-postgres": "nix-postgres",
+        "nix2container": "nix2container_2",
+        "nixpkgs": "nixpkgs_6",
         "pre-commit-hooks": "pre-commit-hooks_3",
+        "process-compose": "process-compose",
+        "services-flake": "services-flake",
         "wasm-bindgen-service-worker": "wasm-bindgen-service-worker"
       }
     },
@@ -1702,11 +2110,11 @@
     "rust-analyzer-src_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1684785219,
-        "narHash": "sha256-1A1waHOB8Pf2BLPtVltsWMP4bhcvTCVUAKpfL9BmCeM=",
+        "lastModified": 1709057983,
+        "narHash": "sha256-ZwIAbq4qRR6Kfdmq9P9/Siieebe2R9dkwTvppsK3oSM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2120c913c28896ed8e6247906f8884939c268683",
+        "rev": "0ac05c05271f31c43d31017cbd288e8737a0edb0",
         "type": "github"
       },
       "original": {
@@ -1734,6 +2142,23 @@
       }
     },
     "rust-analyzer-src_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684785219,
+        "narHash": "sha256-1A1waHOB8Pf2BLPtVltsWMP4bhcvTCVUAKpfL9BmCeM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "2120c913c28896ed8e6247906f8884939c268683",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_7": {
       "flake": false,
       "locked": {
         "lastModified": 1695398941,
@@ -1834,6 +2259,58 @@
     "rust-overlay_4": {
       "inputs": {
         "flake-utils": [
+          "nix-postgres",
+          "pgx-ulid",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nix-postgres",
+          "pgx-ulid",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677812689,
+        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_5": {
+      "inputs": {
+        "flake-utils": "flake-utils_11",
+        "nixpkgs": [
+          "nix-postgres",
+          "pgx-ulid",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679365133,
+        "narHash": "sha256-VSGnA2oXLV0dxViRS1HfwiGJPuQohQQx44OPRImpSeA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f5efdf14ed378aac26cadded4d0c00ca91974d32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_6": {
+      "inputs": {
+        "flake-utils": [
           "wasm-bindgen-service-worker",
           "bomper",
           "bomper",
@@ -1862,7 +2339,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_5": {
+    "rust-overlay_7": {
       "inputs": {
         "flake-utils": [
           "wasm-bindgen-service-worker",
@@ -1891,7 +2368,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_6": {
+    "rust-overlay_8": {
       "inputs": {
         "flake-utils": [
           "wasm-bindgen-service-worker",
@@ -1918,7 +2395,37 @@
         "type": "github"
       }
     },
+    "services-flake": {
+      "locked": {
+        "lastModified": 1709510351,
+        "narHash": "sha256-FIG8YmvSoy99Z7jrcXZi2Mw11lM53Z2ex8cQ1h1Y6eU=",
+        "owner": "justinrubek",
+        "repo": "services-flake",
+        "rev": "577e7d44d9d0314697c625ff1fdbb4ad8b5fade3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "justinrubek",
+        "repo": "services-flake",
+        "type": "github"
+      }
+    },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_10": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2038,14 +2545,29 @@
         "type": "github"
       }
     },
+    "systems_9": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "wasm-bindgen-service-worker": {
       "inputs": {
         "bomper": "bomper_3",
-        "crane": "crane_6",
-        "fenix": "fenix_6",
-        "flake-parts": "flake-parts_6",
-        "nix-filter": "nix-filter_6",
-        "nixpkgs": "nixpkgs_6",
+        "crane": "crane_7",
+        "fenix": "fenix_7",
+        "flake-parts": "flake-parts_7",
+        "nix-filter": "nix-filter_7",
+        "nixpkgs": "nixpkgs_9",
         "pre-commit-hooks": "pre-commit-hooks_6"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,9 @@
       url = "github:nlewo/nix2container";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    process-compose.url = "github:Platonic-Systems/process-compose-flake";
+    services-flake.url = "github:justinrubek/services-flake";
+    nix-postgres.url = "github:justinrubek/nix-postgres";
   };
 
   outputs = inputs @ {
@@ -52,6 +55,11 @@
         inputs.pre-commit-hooks.flakeModule
 
         ./flake-parts/containers.nix
+
+        ./flake-parts/postgres.nix
+
+        inputs.process-compose.flakeModule
+        ./flake-parts/services.nix
       ];
     };
 }


### PR DESCRIPTION
services-flake is used to provide services the application needs to run. For now, this includes postgres which can be used for data storage going forward. Use `nix run .#services` to launch process-compose which will spin up the services.

The http server also depends on a lockpad server being present but this is not ran through the services at this time. Instead lockpad has its own `services` package which functions the same way.

Environment variables have been added that are used to configure dependent services:
- `PRJ_DATA_HOME` - where to persist service data (recommend: set to the absolute path to the `.data` subdirectory of this repo)
- `ANNAPURNA_POSTGRES_PORT` - determines the port to use (note, this is disabled via commenting `listen_port`, but the name is reserved)